### PR TITLE
Add fix for mouseover rapid image UI strobing

### DIFF
--- a/static/toggleProductInfo.js
+++ b/static/toggleProductInfo.js
@@ -2,18 +2,14 @@
   const products = document.getElementsByClassName('productContainer');
 
   [].forEach.call(products, element => {
-    // TODO: mouseenter has better UX, and maybe combined with mouseleave or something else
-    // for mouseover to achieve the truely desired effect...
-    element.addEventListener("mouseenter", e => { toggleProductInfo(element, e) });
+    element.addEventListener("mouseenter", toggleProductInfo);
+    element.addEventListener("mouseleave", toggleProductInfo)
   });
 
-  function toggleProductInfo(element, e) {
-    // TODO: Not producing desired results.
-    e.stopPropagation();
-
-    const images = element.getElementsByClassName('productImage');
-    const stock = element.getElementsByClassName('stockContainer');
-    const description = element.getElementsByClassName('productDescription');
+  function toggleProductInfo() {
+    const images = this.getElementsByClassName('productImage');
+    const stock = this.getElementsByClassName('stockContainer');
+    const description = this.getElementsByClassName('productDescription');
 
     [].forEach.call(images, imageElement => {
       if (imageElement.classList.contains('show')) {


### PR DESCRIPTION
Not sure if it's because of the this and targeting confusion, but stopping the even propagation wasn't having the desired effect... but the mouseover might just be triggering too many events. so i changed it to mouseenter, and while it doesn't achieve the full desired effect, it is better UX.

Another possible thought would be to play with opacity, absolute positioning, and transitions, but that seemed a bit more complex for a quick fix at this point (and might still not work well with mouseover).

2nd commit is fix from pairing... (kept the first commit to remember thought/work process)